### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,11 +7,11 @@ cmsplugin-feedback
 .. |ci| image:: https://travis-ci.org/satyrius/cmsplugin-feedback.png?branch=master
     :target: https://travis-ci.org/satyrius/cmsplugin-feedback
 
-.. |pypi| image:: https://pypip.in/version/cmsplugin-feedback/badge.png?text=pypi
+.. |pypi| image:: https://img.shields.io/pypi/v/cmsplugin-feedback.svg?label=pypi
     :target: https://pypi.python.org/pypi/cmsplugin-feedback/
     :alt: Latest Version
 
-.. |status| image:: https://pypip.in/status/cmsplugin-feedback/badge.png
+.. |status| image:: https://img.shields.io/pypi/status/cmsplugin-feedback.svg
     :target: https://pypi.python.org/pypi/cmsplugin-feedback/
     :alt: Development Status
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20cmsplugin-feedback))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `cmsplugin-feedback`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.